### PR TITLE
Feat: 회원 프로필 조회 기능 구현

### DIFF
--- a/src/main/java/org/kwakmunsu/randsome/domain/member/controller/MemberController.java
+++ b/src/main/java/org/kwakmunsu/randsome/domain/member/controller/MemberController.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.randsome.domain.member.controller.dto.MemberRegisterRequest;
 import org.kwakmunsu.randsome.domain.member.serivce.MemberService;
 import org.kwakmunsu.randsome.domain.member.serivce.dto.CheckResponse;
+import org.kwakmunsu.randsome.domain.member.serivce.dto.MemberProfileResponse;
+import org.kwakmunsu.randsome.global.annotation.AuthMember;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +29,13 @@ public class MemberController extends MemberDocsController {
         Long memberId = memberService.register(request.toServiceRequest());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(memberId);
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<MemberProfileResponse> getProfile(@AuthMember Long memberId) {
+        MemberProfileResponse response = memberService.getProfile(memberId);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/src/main/java/org/kwakmunsu/randsome/domain/member/enums/Role.java
+++ b/src/main/java/org/kwakmunsu/randsome/domain/member/enums/Role.java
@@ -1,9 +1,17 @@
 package org.kwakmunsu.randsome.domain.member.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum Role {
-    ROLE_GUEST,
-    ROLE_MEMBER,
-    ROLE_CANDIDATE,
-    ROLE_ADMIN,
+    ROLE_GUEST     ("손님"),
+    ROLE_MEMBER    ("회원"),
+    ROLE_CANDIDATE ("매칭 후보"),
+    ROLE_ADMIN     ("관리자"),
     ;
+
+    private final String value;
+
 }

--- a/src/main/java/org/kwakmunsu/randsome/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/org/kwakmunsu/randsome/domain/member/repository/MemberRepositoryImpl.java
@@ -40,4 +40,10 @@ public class MemberRepositoryImpl implements MemberRepository {
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_TOKEN));
     }
 
+    @Override
+    public Member findById(Long id) {
+        return memberJpaRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_MEMBER));
+    }
+
 }

--- a/src/main/java/org/kwakmunsu/randsome/domain/member/serivce/MemberRepository.java
+++ b/src/main/java/org/kwakmunsu/randsome/domain/member/serivce/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository {
     boolean existsByNickname(String nickname);
     Member findByLoginId(String loginId);
     Member findByRefreshToken(String refreshToken);
+    Member findById(Long id);
+
 }

--- a/src/main/java/org/kwakmunsu/randsome/domain/member/serivce/MemberService.java
+++ b/src/main/java/org/kwakmunsu/randsome/domain/member/serivce/MemberService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kwakmunsu.randsome.domain.member.entity.Member;
 import org.kwakmunsu.randsome.domain.member.serivce.dto.CheckResponse;
+import org.kwakmunsu.randsome.domain.member.serivce.dto.MemberProfileResponse;
 import org.kwakmunsu.randsome.domain.member.serivce.dto.MemberRegisterServiceRequest;
 import org.kwakmunsu.randsome.global.exception.DuplicationException;
 import org.kwakmunsu.randsome.global.exception.UnAuthenticationException;
@@ -35,6 +36,12 @@ public class MemberService {
             return member;
         }
         throw new UnAuthenticationException(ErrorStatus.INVALID_PASSWORD);
+    }
+
+    public MemberProfileResponse getProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId);
+
+        return MemberProfileResponse.from(member);
     }
 
     // ------------------- 중복 체크용 -------------------

--- a/src/main/java/org/kwakmunsu/randsome/domain/member/serivce/dto/MemberProfileResponse.java
+++ b/src/main/java/org/kwakmunsu/randsome/domain/member/serivce/dto/MemberProfileResponse.java
@@ -1,0 +1,49 @@
+package org.kwakmunsu.randsome.domain.member.serivce.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import org.kwakmunsu.randsome.domain.member.entity.Member;
+import org.kwakmunsu.randsome.domain.member.enums.Mbti;
+
+@Schema(description = "프로필 응답 DTO")
+@Builder
+public record MemberProfileResponse(
+        @Schema(description = "실명", example = "홍길동")
+        String legalName,
+
+        @Schema(description = "닉네임", example = "길동이")
+        String nickname,
+
+        @Schema(description = "성별 (수정 불가)", example = "남자 | 여자")
+        String gender,
+
+        @Schema(description = "역할 (수정 불가)", example = "회원 | 매칭 후보 ")
+        String role,
+
+        @Schema(description = "MBTI 유형", example = "INTJ")
+        Mbti mbti,
+
+        @Schema(description = "자기소개", example = "안녕하세요, 자기소개입니다.")
+        String introduction,
+
+        @Schema(description = "이상형 설명", example = "이상형은 친절한 사람입니다.")
+        String idealDescription,
+
+        @Schema(description = "인스타그램 아이디", example = "hong_gildong")
+        String instagramId
+) {
+
+    public static MemberProfileResponse from(Member member) {
+        return MemberProfileResponse.builder()
+                .legalName(member.getLegalName())
+                .nickname(member.getNickname())
+                .gender(member.getGender().getValue())
+                .role(member.getRole().getValue())
+                .mbti(member.getMbti())
+                .introduction(member.getIntroduction())
+                .idealDescription(member.getIdealDescription())
+                .instagramId(member.getInstagramId())
+                .build();
+    }
+
+}

--- a/src/main/java/org/kwakmunsu/randsome/global/annotation/AuthMember.java
+++ b/src/main/java/org/kwakmunsu/randsome/global/annotation/AuthMember.java
@@ -1,0 +1,14 @@
+package org.kwakmunsu.randsome.global.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Parameter(hidden = true)
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMember {
+
+}

--- a/src/main/java/org/kwakmunsu/randsome/global/annotation/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/org/kwakmunsu/randsome/global/annotation/resolver/AuthMemberArgumentResolver.java
@@ -1,0 +1,41 @@
+package org.kwakmunsu.randsome.global.annotation.resolver;
+
+import static org.kwakmunsu.randsome.global.exception.dto.ErrorStatus.EMPTY_SECURITY_CONTEXT;
+
+import org.kwakmunsu.randsome.global.annotation.AuthMember;
+import org.kwakmunsu.randsome.global.exception.UnAuthenticationException;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthMember.class) &&
+                parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getName() == null) {
+            throw new UnAuthenticationException(EMPTY_SECURITY_CONTEXT);
+        }
+
+        return Long.parseLong(authentication.getName());
+    }
+
+}

--- a/src/main/java/org/kwakmunsu/randsome/global/config/WebMvcConfig.java
+++ b/src/main/java/org/kwakmunsu/randsome/global/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package org.kwakmunsu.randsome.global.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.kwakmunsu.randsome.global.annotation.resolver.AuthMemberArgumentResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Component
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthMemberArgumentResolver authMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authMemberArgumentResolver);
+    }
+
+}

--- a/src/test/java/org/kwakmunsu/randsome/ControllerTestSupport.java
+++ b/src/test/java/org/kwakmunsu/randsome/ControllerTestSupport.java
@@ -13,13 +13,14 @@ import org.kwakmunsu.randsome.domain.matching.controller.MatchingController;
 import org.kwakmunsu.randsome.domain.matching.serivce.MatchingService;
 import org.kwakmunsu.randsome.domain.member.controller.MemberController;
 import org.kwakmunsu.randsome.domain.member.serivce.MemberService;
+import org.kwakmunsu.randsome.global.TestSecurityConfig;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 
-@AutoConfigureMockMvc(addFilters = false)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(
         controllers = {
                 AdminController.class,

--- a/src/test/java/org/kwakmunsu/randsome/global/TestMember.java
+++ b/src/test/java/org/kwakmunsu/randsome/global/TestMember.java
@@ -1,0 +1,16 @@
+package org.kwakmunsu.randsome.global;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = TestSecurityContext.class, setupBefore = TestExecutionEvent.TEST_EXECUTION)
+public @interface TestMember {
+
+    long id() default 1L;
+
+    String role() default "MEMBER";
+
+}

--- a/src/test/java/org/kwakmunsu/randsome/global/TestSecurityConfig.java
+++ b/src/test/java/org/kwakmunsu/randsome/global/TestSecurityConfig.java
@@ -1,0 +1,35 @@
+package org.kwakmunsu.randsome.global;
+
+import lombok.RequiredArgsConstructor;
+import org.kwakmunsu.randsome.domain.member.enums.Role;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/**",
+                                "/api/v1/members/sign-up",
+                                "/api/v1/members/check-login-id",
+                                "/api/v1/members/check-nickname"
+                                ).permitAll()   // 로그인, 회원가입, 토큰 재발급 등은 인증 불필요
+                        .anyRequest().hasAnyAuthority(Role.ROLE_MEMBER.name(), Role.ROLE_CANDIDATE.name())
+                );
+
+        return http.build();
+    }
+
+}

--- a/src/test/java/org/kwakmunsu/randsome/global/TestSecurityContext.java
+++ b/src/test/java/org/kwakmunsu/randsome/global/TestSecurityContext.java
@@ -1,0 +1,33 @@
+package org.kwakmunsu.randsome.global;
+
+import java.util.Collections;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+@Slf4j
+public class TestSecurityContext implements WithSecurityContextFactory<TestMember> {
+
+    @Override
+    public SecurityContext createSecurityContext(TestMember annotation) {
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        GrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + annotation.role());
+        String memberId = String.valueOf(annotation.id());
+
+        log.info("authorId: {}, role: {}", memberId, annotation.role());
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                memberId,
+                null,
+                Collections.singletonList(authority)
+        );
+        securityContext.setAuthentication(authentication);
+
+        return securityContext;
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
✅ `Issue`:  #10 

## 📝작업 내용
- Custom AuthMember annotation 추가
- Test전용 TestSecurityConfig, TestMember, TestSecurityContext 추가
- 회원 프로필 조회 API 구현