### PR TITLE
Feat: 관리자용 매칭 신청 상태 변경 기능 구현

### DIFF
--- a/src/main/java/org/kwakmunsu/randsome/admin/matching/controller/MatchingAdminController.java
+++ b/src/main/java/org/kwakmunsu/randsome/admin/matching/controller/MatchingAdminController.java
@@ -1,16 +1,23 @@
 package org.kwakmunsu.randsome.admin.matching.controller;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.kwakmunsu.randsome.admin.matching.controller.dto.MatchingApplicationStatusUpdateRequest;
 import org.kwakmunsu.randsome.admin.matching.service.MatchingAdminService;
 import org.kwakmunsu.randsome.admin.matching.service.dto.MatchingApplicationListServiceRequest;
 import org.kwakmunsu.randsome.domain.matching.enums.MatchingStatus;
 import org.kwakmunsu.randsome.domain.matching.repository.dto.MatchingApplicationListResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequestMapping("/api/v1/admin/matching")
 @RequiredArgsConstructor
 @RestController
 public class MatchingAdminController extends MatchingAdminDocsController {
@@ -18,15 +25,26 @@ public class MatchingAdminController extends MatchingAdminDocsController {
     private final MatchingAdminService matchingAdminService;
 
     @Override
-    @GetMapping("/api/v1/admin/matching/applications")
+    @GetMapping("/applications")
     public ResponseEntity<MatchingApplicationListResponse> getApplications(
             @RequestParam MatchingStatus status,
             @RequestParam(defaultValue = "1") @Min(1) int page
     ) {
         MatchingApplicationListServiceRequest request = new MatchingApplicationListServiceRequest(status, page);
-        MatchingApplicationListResponse response = matchingAdminService.getMatchingApplications(request);
+        MatchingApplicationListResponse response = matchingAdminService.findApplicationsByStatus(request);
 
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @PutMapping("/applications/{applicationId}/status")
+    public ResponseEntity<Void> updateApplicationStatus(
+            @PathVariable Long applicationId,
+            @Valid @RequestBody MatchingApplicationStatusUpdateRequest request
+    ) {
+        matchingAdminService.updateApplicationStatus(applicationId, request.status());
+
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/org/kwakmunsu/randsome/admin/matching/controller/dto/MatchingApplicationStatusUpdateRequest.java
+++ b/src/main/java/org/kwakmunsu/randsome/admin/matching/controller/dto/MatchingApplicationStatusUpdateRequest.java
@@ -1,0 +1,16 @@
+package org.kwakmunsu.randsome.admin.matching.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import org.kwakmunsu.randsome.domain.matching.enums.MatchingStatus;
+
+@Builder
+@Schema(description = "매칭 신청 상태 업데이트 요청 DTO")
+public record MatchingApplicationStatusUpdateRequest(
+        @Schema(description = "매칭 상태", example = "COMPLETED | FAILED")
+        @NotNull(message = "매칭 상태는 필수입니다.")
+        MatchingStatus status
+) {
+
+}

--- a/src/main/java/org/kwakmunsu/randsome/admin/matching/service/MatchingAdminService.java
+++ b/src/main/java/org/kwakmunsu/randsome/admin/matching/service/MatchingAdminService.java
@@ -1,19 +1,92 @@
 package org.kwakmunsu.randsome.admin.matching.service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.kwakmunsu.randsome.admin.matching.service.dto.MatchingApplicationListServiceRequest;
+import org.kwakmunsu.randsome.domain.matching.entity.Matching;
+import org.kwakmunsu.randsome.domain.matching.entity.MatchingApplication;
+import org.kwakmunsu.randsome.domain.matching.enums.MatchingStatus;
+import org.kwakmunsu.randsome.domain.matching.enums.MatchingType;
 import org.kwakmunsu.randsome.domain.matching.repository.dto.MatchingApplicationListResponse;
 import org.kwakmunsu.randsome.domain.matching.serivce.repository.MatchingApplicationRepository;
+import org.kwakmunsu.randsome.domain.matching.serivce.repository.MatchingRepository;
+import org.kwakmunsu.randsome.domain.member.entity.Member;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@RequiredArgsConstructor
+@Slf4j
 @Service
 public class MatchingAdminService {
 
-    private final MatchingApplicationRepository matchingApplicationRepository;
+    private final MatchingRepository matchingRepository;
+    private final MatchingApplicationRepository applicationRepository;
+    private final Map<MatchingType, MatchingProvider> matchingProviders;
 
-    public MatchingApplicationListResponse getMatchingApplications(MatchingApplicationListServiceRequest request) {
-        return matchingApplicationRepository.findAllByStatus(request.status(), request.page());
+    public MatchingAdminService(
+            MatchingRepository matchingRepository,
+            MatchingApplicationRepository applicationRepository,
+            List<MatchingProvider> matchingProviders
+    ) {
+        this.matchingRepository = matchingRepository;
+        this.applicationRepository = applicationRepository;
+        this.matchingProviders = matchingProviders.stream()
+                .collect(Collectors.toMap(
+                        MatchingProvider::getType,
+                        provider -> provider
+                ));
+    }
+    /**
+     * 매칭 신청 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public MatchingApplicationListResponse findApplicationsByStatus(MatchingApplicationListServiceRequest request) {
+        return applicationRepository.findAllByStatus(request.status(), request.page());
+    }
+
+    /**
+     * 매칭 신청 상태 변경 (승인/거절)
+     */
+    @Transactional
+    public void updateApplicationStatus(Long applicationId, MatchingStatus status) {
+        log.info("Updating application status - ID: {}, newStatus: {}", applicationId, status);
+
+        MatchingApplication application = applicationRepository.findById(applicationId);
+        switch (status) {
+            case COMPLETED -> approveAndExecuteMatching(application);
+            case FAILED -> application.fail();
+        }
+    }
+
+    /**
+     * 매칭 승인 및 실행
+     */
+    private void approveAndExecuteMatching(MatchingApplication application) {
+        executeMatching(application);
+        application.complete();
+    }
+
+    /**
+     * 매칭 실행
+     */
+    private void executeMatching(MatchingApplication application) {
+        MatchingProvider provider = matchingProviders.get(application.getMatchingType());
+        List<Member> matchedCandidates = provider.match(application.getRequester());
+
+        saveMatchingResults(application, matchedCandidates);
+
+        // TODO: notification publish
+    }
+
+    /**
+     * 매칭 결과 저장
+     */
+    private void saveMatchingResults(MatchingApplication application, List<Member> matchedCandidates) {
+        List<Matching> results = matchedCandidates.stream()
+                .map(c -> Matching.create(application, c))
+                .toList();
+        matchingRepository.saveAll(results);
     }
 
 }

--- a/src/main/java/org/kwakmunsu/randsome/admin/matching/service/MatchingProvider.java
+++ b/src/main/java/org/kwakmunsu/randsome/admin/matching/service/MatchingProvider.java
@@ -1,10 +1,12 @@
 package org.kwakmunsu.randsome.admin.matching.service;
 
+import java.util.List;
 import org.kwakmunsu.randsome.domain.matching.enums.MatchingType;
+import org.kwakmunsu.randsome.domain.member.entity.Member;
 
 public interface MatchingProvider {
 
     MatchingType getType();
-    void match(Long memberId);
+    List<Member> match(Member requester);
 
 }

--- a/src/main/java/org/kwakmunsu/randsome/admin/matching/service/RandomMatchingProvider.java
+++ b/src/main/java/org/kwakmunsu/randsome/admin/matching/service/RandomMatchingProvider.java
@@ -1,6 +1,8 @@
 package org.kwakmunsu.randsome.admin.matching.service;
 
+import java.util.List;
 import org.kwakmunsu.randsome.domain.matching.enums.MatchingType;
+import org.kwakmunsu.randsome.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,8 +14,8 @@ public class RandomMatchingProvider implements MatchingProvider {
     }
 
     @Override
-    public void match(Long memberId) {
-
+    public List<Member> match(Member requester) {
+        return List.of();
     }
 
 }

--- a/src/main/java/org/kwakmunsu/randsome/domain/matching/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/org/kwakmunsu/randsome/domain/matching/repository/MatchingRepositoryImpl.java
@@ -1,11 +1,21 @@
 package org.kwakmunsu.randsome.domain.matching.repository;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.kwakmunsu.randsome.domain.matching.entity.Matching;
 import org.kwakmunsu.randsome.domain.matching.serivce.repository.MatchingRepository;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
 public class MatchingRepositoryImpl implements MatchingRepository {
+
+    private final MatchingJpaRepository matchingJpaRepository;
+
+    // 최대 5건이라 JPA saveAll 사용
+    @Override
+    public void saveAll(List<Matching> results) {
+        matchingJpaRepository.saveAll(results);
+    }
 
 }

--- a/src/main/java/org/kwakmunsu/randsome/domain/matching/serivce/repository/MatchingRepository.java
+++ b/src/main/java/org/kwakmunsu/randsome/domain/matching/serivce/repository/MatchingRepository.java
@@ -1,5 +1,10 @@
 package org.kwakmunsu.randsome.domain.matching.serivce.repository;
 
+import java.util.List;
+import org.kwakmunsu.randsome.domain.matching.entity.Matching;
+
 public interface MatchingRepository {
+
+    void saveAll(List<Matching> results);
 
 }

--- a/src/main/java/org/kwakmunsu/randsome/infrastructure/mathcing/IdealRandomMatchingProvider.java
+++ b/src/main/java/org/kwakmunsu/randsome/infrastructure/mathcing/IdealRandomMatchingProvider.java
@@ -1,7 +1,9 @@
 package org.kwakmunsu.randsome.infrastructure.mathcing;
 
+import java.util.List;
 import org.kwakmunsu.randsome.admin.matching.service.MatchingProvider;
 import org.kwakmunsu.randsome.domain.matching.enums.MatchingType;
+import org.kwakmunsu.randsome.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,8 +15,8 @@ public class IdealRandomMatchingProvider implements MatchingProvider {
     }
 
     @Override
-    public void match(Long memberId) {
-
+    public List<Member> match(Member requester) {
+        return List.of();
     }
 
 }

--- a/src/test/java/org/kwakmunsu/randsome/admin/matching/service/MatchingAdminServiceIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/randsome/admin/matching/service/MatchingAdminServiceIntegrationTest.java
@@ -58,7 +58,7 @@ class MatchingAdminServiceIntegrationTest {
         var request = new MatchingApplicationListServiceRequest(MatchingStatus.PENDING, 1);
 
         // when
-        MatchingApplicationListResponse response = matchingAdminService.getMatchingApplications(request);
+        MatchingApplicationListResponse response = matchingAdminService.findApplicationsByStatus(request);
 
         // then
         assertThat(response.responses().size()).isEqualTo(DEFAULT_PAGE_SIZE); // 20개
@@ -77,7 +77,7 @@ class MatchingAdminServiceIntegrationTest {
         var request = new MatchingApplicationListServiceRequest(MatchingStatus.PENDING, 2);
 
         // when
-        MatchingApplicationListResponse response = matchingAdminService.getMatchingApplications(request);
+        MatchingApplicationListResponse response = matchingAdminService.findApplicationsByStatus(request);
 
         // then
         assertThat(response.responses().size()).isEqualTo(5); // 25 - 20 = 5개
@@ -96,7 +96,7 @@ class MatchingAdminServiceIntegrationTest {
         var request = new MatchingApplicationListServiceRequest(MatchingStatus.COMPLETED, 1);
 
         // when
-        MatchingApplicationListResponse response = matchingAdminService.getMatchingApplications(request);
+        MatchingApplicationListResponse response = matchingAdminService.findApplicationsByStatus(request);
 
         // then
         assertThat(response.responses().size()).isEqualTo(DEFAULT_PAGE_SIZE);
@@ -115,7 +115,7 @@ class MatchingAdminServiceIntegrationTest {
         var request = new MatchingApplicationListServiceRequest(MatchingStatus.COMPLETED, 2);
 
         // when
-        MatchingApplicationListResponse response = matchingAdminService.getMatchingApplications(request);
+        MatchingApplicationListResponse response = matchingAdminService.findApplicationsByStatus(request);
 
         // then
         assertThat(response.responses().size()).isEqualTo(5);
@@ -134,7 +134,7 @@ class MatchingAdminServiceIntegrationTest {
         var request = new MatchingApplicationListServiceRequest(MatchingStatus.FAILED, 1);
 
         // when
-        MatchingApplicationListResponse response = matchingAdminService.getMatchingApplications(request);
+        MatchingApplicationListResponse response = matchingAdminService.findApplicationsByStatus(request);
 
         // then
         assertThat(response.responses().size()).isEqualTo(DEFAULT_PAGE_SIZE);
@@ -152,7 +152,7 @@ class MatchingAdminServiceIntegrationTest {
         var request = new MatchingApplicationListServiceRequest(MatchingStatus.FAILED, 2);
 
         // when
-        MatchingApplicationListResponse response = matchingAdminService.getMatchingApplications(request);
+        MatchingApplicationListResponse response = matchingAdminService.findApplicationsByStatus(request);
 
         // then
         assertThat(response.responses().size()).isEqualTo(5);
@@ -171,9 +171,9 @@ class MatchingAdminServiceIntegrationTest {
         var completedRequest = new MatchingApplicationListServiceRequest(MatchingStatus.COMPLETED, 1);
         var failedRequest = new MatchingApplicationListServiceRequest(MatchingStatus.FAILED, 1);
 
-        var pendingResponse = matchingAdminService.getMatchingApplications(pendingRequest);
-        var completedResponse = matchingAdminService.getMatchingApplications(completedRequest);
-        var failedResponse = matchingAdminService.getMatchingApplications(failedRequest);
+        var pendingResponse = matchingAdminService.findApplicationsByStatus(pendingRequest);
+        var completedResponse = matchingAdminService.findApplicationsByStatus(completedRequest);
+        var failedResponse = matchingAdminService.findApplicationsByStatus(failedRequest);
 
         // then
         assertThat(pendingResponse.totalCount()).isEqualTo(APPLICATION_PER_STATUS);
@@ -195,8 +195,8 @@ class MatchingAdminServiceIntegrationTest {
         var secondPageRequest = new MatchingApplicationListServiceRequest(MatchingStatus.PENDING, 2);
 
         // when
-        var firstPageResponse = matchingAdminService.getMatchingApplications(firstPageRequest);
-        var secondPageResponse = matchingAdminService.getMatchingApplications(secondPageRequest);
+        var firstPageResponse = matchingAdminService.findApplicationsByStatus(firstPageRequest);
+        var secondPageResponse = matchingAdminService.findApplicationsByStatus(secondPageRequest);
 
         // then
         var firstPageIds = firstPageResponse.responses().stream()
@@ -223,8 +223,8 @@ class MatchingAdminServiceIntegrationTest {
         var secondPageRequest = new MatchingApplicationListServiceRequest(MatchingStatus.PENDING, 2);
 
         // when
-        var firstPageResponse = matchingAdminService.getMatchingApplications(firstPageRequest);
-        var secondPageResponse = matchingAdminService.getMatchingApplications(secondPageRequest);
+        var firstPageResponse = matchingAdminService.findApplicationsByStatus(firstPageRequest);
+        var secondPageResponse = matchingAdminService.findApplicationsByStatus(secondPageRequest);
 
         // then
         var firstPageApplication = firstPageResponse.responses();

--- a/src/test/java/org/kwakmunsu/randsome/admin/matching/service/MatchingAdminServiceTest.java
+++ b/src/test/java/org/kwakmunsu/randsome/admin/matching/service/MatchingAdminServiceTest.java
@@ -1,0 +1,164 @@
+package org.kwakmunsu.randsome.admin.matching.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kwakmunsu.randsome.domain.matching.entity.Matching;
+import org.kwakmunsu.randsome.domain.matching.entity.MatchingApplication;
+import org.kwakmunsu.randsome.domain.matching.enums.MatchingStatus;
+import org.kwakmunsu.randsome.domain.matching.enums.MatchingType;
+import org.kwakmunsu.randsome.domain.matching.serivce.repository.MatchingApplicationRepository;
+import org.kwakmunsu.randsome.domain.matching.serivce.repository.MatchingRepository;
+import org.kwakmunsu.randsome.domain.member.MemberFixture;
+import org.kwakmunsu.randsome.domain.member.entity.Member;
+import org.kwakmunsu.randsome.global.exception.NotFoundException;
+import org.kwakmunsu.randsome.global.exception.dto.ErrorStatus;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingAdminServiceTest {
+
+    @Mock
+    private MatchingRepository matchingRepository;
+
+    @Mock
+    private MatchingApplicationRepository applicationRepository;
+
+    @Mock
+    private MatchingProvider randomMatchingProvider;
+
+    @Mock
+    private MatchingProvider idealMatchingProvider;
+
+    private MatchingAdminService matchingAdminService;
+
+    private Member requester;
+    private MatchingApplication application;
+    private List<Member> matchedMembers;
+
+    @BeforeEach
+    void setUp() {
+        given(randomMatchingProvider.getType()).willReturn(MatchingType.RANDOM_MATCHING);
+        given(idealMatchingProvider.getType()).willReturn(MatchingType.IDEAL_MATCHING);
+
+        matchingAdminService = new MatchingAdminService(
+                matchingRepository,
+                applicationRepository,
+                List.of(randomMatchingProvider, idealMatchingProvider)
+        );
+
+        // 테스트 데이터
+        requester = MemberFixture.createMember(1L, "requester");
+        application = createApplication(1L, requester, MatchingType.RANDOM_MATCHING);
+        matchedMembers = List.of(
+                MemberFixture.createMember(10L, "candidate1"),
+                MemberFixture.createMember(11L, "candidate2"),
+                MemberFixture.createMember(12L, "candidate3")
+        );
+    }
+
+    @DisplayName("매칭 신청을 승인하면 매칭을 실행하고 상태를 COMPLETED로 변경한다")
+    @Test
+    void updateApplicationStatusApprove() {
+        // given
+        given(applicationRepository.findById(1L)).willReturn(application);
+        given(randomMatchingProvider.match(requester)).willReturn(matchedMembers);
+
+        // when
+        matchingAdminService.updateApplicationStatus(1L, MatchingStatus.COMPLETED);
+
+        // then
+        assertThat(application.getMatchingStatus()).isEqualTo(MatchingStatus.COMPLETED);
+        then(randomMatchingProvider).should(times(1)).match(requester);
+        then(matchingRepository).should(times(1)).saveAll(anyList());
+    }
+
+    @DisplayName("매칭 신청을 거절하면 상태를 FAILED로 변경하고 매칭을 실행하지 않는다")
+    @Test
+    void updateApplicationStatusReject() {
+        // given
+        given(applicationRepository.findById(1L)).willReturn(application);
+
+        // when
+        matchingAdminService.updateApplicationStatus(1L, MatchingStatus.FAILED);
+
+        // then
+        assertThat(application.getMatchingStatus()).isEqualTo(MatchingStatus.FAILED);
+        then(randomMatchingProvider).should(never()).match(any());
+        then(matchingRepository).should(never()).saveAll(anyList());
+    }
+
+    @DisplayName("매칭 실행 시 Provider 에서 반환한 회원 수만큼 Matching 엔티티를 생성한다")
+    @Test
+    void executeMatchingCreatesCorrectNumberOfMatchings() {
+        // given
+        given(applicationRepository.findById(1L)).willReturn(application);
+        given(randomMatchingProvider.match(requester)).willReturn(matchedMembers);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+
+        // when
+        matchingAdminService.updateApplicationStatus(1L, MatchingStatus.COMPLETED);
+
+        // then
+        then(matchingRepository).should().saveAll(captor.capture());
+        List<Matching> savedMatchings = captor.getValue();
+
+        assertThat(savedMatchings).hasSize(3);
+        assertThat(savedMatchings)
+                .extracting(m -> m.getSelectedMember().getId())
+                .containsExactlyInAnyOrder(10L, 11L, 12L);
+    }
+
+    @DisplayName("이상형 매칭 타입일 때 IdealMatchingProvider를 사용한다")
+    @Test
+    void executeMatchingUsesCorrectProvider() {
+        // given
+        MatchingApplication idealApplication = createApplication(
+                2L, requester, MatchingType.IDEAL_MATCHING
+        );
+        given(applicationRepository.findById(2L)).willReturn(idealApplication);
+        given(idealMatchingProvider.match(requester)).willReturn(matchedMembers);
+
+        // when
+        matchingAdminService.updateApplicationStatus(2L, MatchingStatus.COMPLETED);
+
+        // then
+        then(idealMatchingProvider).should(times(1)).match(requester);
+        then(randomMatchingProvider).should(never()).match(any());
+    }
+
+    @DisplayName("존재하지 않는 신청 ID로 상태 변경 시 예외가 발생한다")
+    @Test
+    void updateApplicationStatusNotFound() {
+        // given
+        given(applicationRepository.findById(999L))
+                .willThrow(new NotFoundException(ErrorStatus.NOT_FOUND_MATCHING_APPLICATION));
+
+        // when & then
+        assertThatThrownBy(() ->
+                matchingAdminService.updateApplicationStatus(999L, MatchingStatus.COMPLETED)
+        ).isInstanceOf(NotFoundException.class);
+    }
+
+    private MatchingApplication createApplication(Long id, Member requester, MatchingType type) {
+        MatchingApplication app = MatchingApplication.create(requester, type, 3);
+        ReflectionTestUtils.setField(app, "id", id);
+        return app;
+    }
+
+}

--- a/src/test/java/org/kwakmunsu/randsome/domain/member/MemberFixture.java
+++ b/src/test/java/org/kwakmunsu/randsome/domain/member/MemberFixture.java
@@ -46,4 +46,11 @@ public class MemberFixture {
         return member;
     }
 
+    public static Member createMember(Long id, String nickname) {
+        var serviceRequest = createMemberRegisterRequest("loginId", nickname).toServiceRequest();
+        Member member = serviceRequest.toEntity("encryptedPassword");
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
✅ `Issue`:  #27 

## 📝작업 내용
- 관리자 매칭 신청 상태 업데이트 API 추가
- 매칭 신청 승인 시 자동 매칭 실행 인터페이스 생성
- 전략 패턴 기반 매칭 Provider 구조 적용
- 매칭 신청 조회 메서드명 리팩토링 (getMatchingApplications → findApplicationsByStatus)
- 단위 테스트 작성